### PR TITLE
add grpcio-tools to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 protobuf>=3.5.1
 aiogrpc>=1.5
 grpcio>=1.11.0
+grpcio-tools>=1.11.0


### PR DESCRIPTION
`run_protoc.sh` fails without `grpcio-tools` installed.