### PR TITLE
[wip] git: contributor and organization map

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,120 @@
+# PX4 .mailmap
+# See this guide for help modifying this file https://github.com/sympy/sympy/wiki/Using-.mailmap
+# Please append your entry
+# Example use of this map:
+#   git log --pretty='%aN <%aE>' | sort | uniq -c | sort -rn | HEAD -10
+
+Alessandro Simovic <alessandro@yuneecresearch.com> alessandro <alessandro@yuneecresearch.com>
+Alessandro Simovic <alessandro@yuneecresearch.com> alessandro <3762382+potaito@users.noreply.github.com>
+Alessandro Simovic <alessandro@yuneecresearch.com> alessandro <potaito@users.noreply.github.com>
+Alexandr Kondratev <theg4sh@gmail.com> <theg4sh@gmail.com>
+Amir Melzer <amir.melzer@mavt.ethz.ch> <amir.melzer@mavt.ethz.ch>
+Anthony Lamping <lamping.ap@gmail.com> <lamping.ap@gmail.com>
+Beat Küng <beat-kueng@gmx.net> <beat-kueng@gmx.net>
+Carl Olsson <carlolsson.co@gmail.com> <carlolsson.co@gmail.com>
+Daniel Agar <daniel@agar.ca> <daniel@agar.ca>
+Daniele Pettenuzzo <daniele@px4.io> Daniele Pettenuzzo <dani.pettenuzzo@gmail.com>
+Daniele Pettenuzzo <daniele@px4.io> DanielePettenuzzo <35664507+DanielePettenuzzo@users.noreply.github.com>
+Daniele Pettenuzzo <daniele@px4.io> Daniele Pettenuzzo <35664507+DanielePettenuzzo@users.noreply.github.com>
+Daniele Pettenuzzo <daniele@px4.io> Daniele Pettenuzzo <DanielePettenuzzo@users.noreply.github.com>
+Daniele Pettenuzzo <daniele@px4.io> DanielePettenuzzo <daniele@px4.io>
+David Riseborough <drisebor@hotmail.com>
+David Sidrane <david_s5@nscdg.com>
+Dennis Mannhart <dennis@yuneecresearch.com> Dennis Mannhart <dennis.mannhart@gmail.com>
+Dennis Mannhart <dennis@yuneecresearch.com> Dennis Mannhart <dennis@px4.io>
+Elia Tarasov <elias.tarasov@gmail.com>
+Florian Achermann <florian.achermann@mavt.ethz.ch>
+Hamish Willee <hamishwillee@gmail.com>
+Ivo Drescher <ivo.drescher@gmail.com>
+Jake Dahl <jacob.dahl@tealdrones.com>
+Johannes Brand <johannes@auterion.com>
+Joshua Whitehead <josh.whitehead@dornerworks.com>
+Julian Oes <julian@oes.ch>
+Julian Oes <julian@oes.ch> Julian Oes <joes@student.ethz.ch>
+Julien Lecoeur <julien.lecoeur@gmail.com>
+Julien Lecoeur <julien.lecoeur@gmail.com> Julien Lecoeur <jlecoeur@users.noreply.github.com>
+Julien Lecoeur <julien.lecoeur@gmail.com> Julien Lecoeur <julien.lecoeur@epfl.ch>
+Jun-Tao <jt.li@yuneec.com>
+Karl Schwabe <ksschwabe@gmail.com>
+Lorenz Meier <lorenz@px4.io> Lorenz Meier <lm@inf.ethz.ch>
+Matthias Grob <maetugr@gmail.com>
+Martin Trgina <martin.trgina@belladati.com>
+Martina Rivizzigno <martina@rivizzigno.it>
+Mateusz Sadowski <msadowski90@gmail.com>
+Mohammed Kabir <kabir@uasys.io>
+Mohammed Kabir <kabir@uasys.io> Kabir Mohammed <mhkabir98@gmail.com>
+Oleg Kalachev <okalachev@gmail.com>
+PX4 Bots <bot@px4.io>
+PX4 Bots <bot@px4.io> PX4 Build Bot <bot@px4.io>
+PX4 Bots <bot@px4.io> PX4 Build Bot <bot@pixhawk.org>
+PX4 Bots <bot@px4.io> PX4 Jenkins <bot@pixhawk.org>
+PX4 Bots <bot@px4.io> PX4BuildBot <bot@pixhawk.org>
+PX4 Bots <bot@px4.io> PX4BuildBot <bot@px4.io>
+PX4 Bots <bot@px4.io> PX4BuildBot <bot@px4.io>
+Paul Riseborough <p_riseborough@live.com.au>
+Paul Riseborough <p_riseborough@live.com.au> Paul Riseborough <priseborough@users.noreply.github.com>
+Philipp Oettershagen <philipp.oettershagen@mavt.ethz.ch>
+Phillip Kocmoud <phil@itchy.io>
+Roman Bapst <roman@px4.io> Roman Bapst <bapstroman@gmail.com>
+Roman Bapst <roman@px4.io> Roman Bapst <romanbapst@yahoo.de>
+Roman Bapst <roman@px4.io> Roman Bapst <bapstr@ethz.ch>
+Roman Bapst <roman@px4.io> tumbili <roman@px4.io>
+Roman Bapst <roman@px4.io> Roman <romanbapst@gmail.com>
+Roman Bapst <roman@px4.io> Roman <bapstroman@gmail.com>
+Roman Bapst <roman@px4.io> Roman <romanbapst@gmail.com>
+Roman Bapst <roman@px4.io> Roman <bapstr@ethz.ch>
+Roman Bapst <roman@px4.io> tumbili <bapstr@ethz.ch>
+Sander Smeets <sander@droneslab.com>
+Simone Guscetti <simone@yuneecresearch.com> Simone Guscetti <simone@px4.io>
+Simone Guscetti <simone@yuneecresearch.com> Simone Guscetti <simone@yuneecresearch.com>
+Simone Guscetti <simone@yuneecresearch.com> Simone Guscetti <simonegu@student.ethz.ch>
+Simone Guscetti <simone@yuneecresearch.com> Simone Guscetti <simonegu@users.noreply.github.com>
+Sugnan Prabhu <sugnan.prabhu.s@intel.com>
+Nuno Marques <n.marques21@hotmail.com>
+Thomas Stastny <thomas.stastny@mavt.ethz.ch>
+Alex Klimaj <alex.klimaj@tealdrones.com>
+Alex Klimaj <alex.klimaj@tealdrones.com> AlexKlimaj <alexklimaj@gmail.com>
+Barza Nisar <nisarb@student.ethz.ch> barzanisar <nisarb@student.ethz.ch>
+Mark Sauder <mcsauder@gmail.com> mcsauder <mcsauder@greypointcorp.com>
+Mark Sauder <mcsauder@gmail.com> mcsauder <mcsauder@gmail.com>
+SungTae Moon <munhoney@gmail.com> stmoon <munhoney@gmail.com>
+Mathieu Bresciani <brescianimathieu@gmail.com>
+Nick Anthony <nickmanthony@hotmail.com>
+Nick Anthony <nickexists@hotmail.com>
+Nick Anthony <nickexists@hotmail.com> Nick Anthony <nanthony@brewerscience.com>
+Nick Anthony <nickexists@hotmail.com> nanthony21 <nickexists@hotmail.com>
+Nathan Tsoi <nathan@vertile.com>
+Ritul Jasuja <ritul.jasuja@intel.com> ritul jasuja <ritul.jasuja@intel.com>
+Avinash Reddy Palleti <avinash.reddy.palleti@intel.com> avinash-palleti <avinash.reddy.palleti@intel.com>
+Otávio Pontes <otavio.pontes@intel.com> Otávio <otavio.pontes@intel.com>
+Gustavo Jose de Sousa <gustavo.sousa@intel.com> Gustavo Jose de Sousa <gustavo.sousa@intel.com>
+Jim Wilson <jwilson@qti.qualcomm.com> jwilson <jwilson@qti.qualcomm.com>
+bharathr <bharathr@qti.qualcomm.com> bharathr <bharathr@qti.qualcomm.com>
+Greg Nutt <gnutt@nuttx.org> patacongo <patacongo@7fd9a85b-ad96-42d3-883c-3090e2eb8679>
+Greg Nutt <gnutt@nuttx.org> patacongo <patacongo@42af7a65-404d-4744-a932-0658087f49c3>
+Andreas Antener <antener_a@gmx.ch> Andreas Daniel Antener <antener_a@gmx.ch>
+Andrew Tridgell <andrew@tridgell.net> Andrew Tridgell <tridge@samba.org>
+Christoph Tobler <christoph@yuneecresearch.com> ChristophTobler <christoph@yuneecresearch.com>
+Christoph Tobler <christoph@yuneecresearch.com> ChristophTobler <ChristophTobler@users.noreply.github.com>
+Christoph Tobler <christoph@yuneecresearch.com> ChristophTobler <christoph@px4.io>
+Christoph Tobler <christoph@yuneecresearch.com> ChristophTobler <christoph.tob@gmail.com>
+Nicolas de Palezieux <ndepal@gmail.com>
+Nicolas de Palezieux <ndepal@gmail.com> Nicolas de Palezieux <ndepal@users.noreply.github.com>
+David Royer <dave@aerotenna.com>
+Ramón Roche <mrpollo@gmail.com>
+Keenan Johnson <keenan.johnson@gmail.com>
+Friedrich Beckmann <friedrich.beckmann@gmx.de>
+Bart Slinger <bartslinger@gmail.com> <bartslinger@users.noreply.github.com>
+Don Gagne <don@thegagnes.com> Don Gagne <DonLakeFlyer@users.noreply.github.com>
+Don Gagne <don@thegagnes.com> DonLakeFlyer <don@thegagnes.com>
+Don Gagne <don@thegagnes.com> Don Gagne <dongagne@outlook.com>
+Don Gagne <don@thegagnes.com> Don Gagne <Don@don-laptop.local>
+Anton Babushkin <anton.babushkin@me.com>
+Prashanth Shakthi <shakthi.prashanth.m@intel.com>
+Prashanth Shakthi <shakthi.prashanth.m@intel.com> Shakthi Prashanth M <shakthi.prashanth.m@intel.com>
+Lalit Kumar <lalit.kumar.begani@intel.com>
+Marjory Silvestre <marjory.silvestre@gmail.com>
+Marjory Silvestre <marjory.silvestre@gmail.com> ayameMBS <37342953+ayameMBS@users.noreply.github.com>
+Jonas Vautherin <jonas.vautherin@gmail.com>
+Jonas Vautherin <jonas.vautherin@gmail.com> Jones <jones@jones-vostok.home>
+Matthias Riegler <riegler.matthias2@gmail.com> Matthias Riegler <matthias@xvzf.tech>

--- a/.organizationmap
+++ b/.organizationmap
@@ -1,0 +1,111 @@
+#
+# More information at
+#  http://tracker.ceph.com/projects/ceph/wiki/Ceph_contributors_list_maintenance_guide
+#
+# See .githubmap for GitHub username contributors
+# See .mailmap for name and mail normalization.
+# See .peoplemap for unique list of people
+#
+# To display the 10 organization who contributed
+# most commits to ceph ( requires git >= 1.8.4 ):
+#
+# git log --pretty='%aN <%aE>' | \
+#   git -c mailmap.file=.organizationmap check-mailmap --stdin | \
+#   sort | uniq -c | sort -rn | nl | head -10
+#     1	13235 Auterion <contact@auterion.com>
+#     2	4106 Unaffiliated <no@organization.net>
+#     3	2076 Yuneec Research <contact@yuneecresearch.com>
+#     4	1408 Nuttx <contact@nuttx.org>
+#     5	 977 Anton Babushkin <anton.babushkin@me.com>
+#     6	 811 px4dev <px4@purgatory.org>
+#     7	 720 Qualcomm <contact@qualcomm.com>
+#     8	 421 UAVenture <contact@uaventure.com>
+#     9	 295 James Goppert <james.goppert@gmail.com>
+#    10	 244 Mark Whitehorn <kd0aij@gmail.com>
+3DR <contact@3dr.com> Dmitry Malakhov <dmitry.malakhov@3drobotics.com>
+3DR <contact@3dr.com> Douglas Silva <silvadouglasw@gmail.com>
+Aerotenna <contact@aerotenna> David Royer <dave@aerotenna.com>
+Auterion <contact@auterion.com> Lorenz Meier <lorenz@px4.io>
+Auterion <contact@auterion.com> Beat Küng <beat-kueng@gmx.net>
+Auterion <contact@auterion.com> Daniele Pettenuzzo <daniele@px4.io>
+Auterion <contact@auterion.com> Roman Bapst <roman@px4.io>
+Auterion <contact@auterion.com> Paul Riseborough <p_riseborough@live.com.au>
+Auterion <contact@auterion.com> Mathieu Bresciani <brescianimathieu@gmail.com>
+Auterion <contact@auterion.com> Johannes Brand <johannes@auterion.com>
+Auterion <contact@auterion.com> Barza Nisar <nisarb@student.ethz.ch>
+Auterion <contact@auterion.com> Thomas Gubler <thomasgubler@gmail.com>
+Auterion <contact@auterion.com> Jonas Vautherin <jonas.vautherin@gmail.com>
+Auterion <contact@auterion.com> Thomas Etter <thomas.etter@auterion.com>
+Auterion <contact@auterion.com> Marjory Silvestre <marjory.silvestre@gmail.com>
+Auterion <contact@auterion.com> Hamish Willee <hamishwillee@gmail.com>
+BellaDati <contact@belladati.com> Martin Trgina <martin.trgina@belladati.com>
+Copter Express <contact@copterexpress.com> Oleg Kalachev <okalachev@gmail.com>
+Copter Express <contact@copterexpress.com> Elia Tarasov <elias.tarasov@gmail.com>
+Drotek <contact@drotek.com> Kevin Lopez Alvarez <kevin.lopez.alvarez@drotek.com>
+Dronecode <contact@dronecode.com> Ramón Roche <mrpollo@gmail.com>
+ETH Zurich <contact@student.ethz.ch> Florian Achermann <florian.achermann@mavt.ethz.ch>
+ETH Zurich <contact@student.ethz.ch> Philipp Oettershagen <philipp.oettershagen@mavt.ethz.ch>
+ETH Zurich <contact@student.ethz.ch> Thomas Mantel <thomas.mantel@mavt.ethz.ch>
+ETH Zurich <contact@student.ethz.ch> Ivo Drescher <ivo.drescher@gmail.com>
+ETH Zurich <contact@student.ethz.ch> Thomas Stastny <thomas.stastny@mavt.ethz.ch>
+EPFL <contact@epfl.ch> Julien Lecoeur <julien.lecoeur@gmail.com>
+Fotokite <contact@fotokite.com> Karl Schwabe <ksschwabe@gmail.com>
+Impossible Aerospace <contact@impossible.aero> Keenan Johnson <keenan.johnson@gmail.com>
+Intel <contact@intel.com> Sugnan Prabhu <sugnan.prabhu.s@intel.com>
+Intel <contact@intel.com> José Roberto de Souza <jose.souza@intel.com>
+Intel <contact@intel.com> Lucas De Marchi <lucas.demarchi@intel.com>
+Intel <contact@intel.com> Avinash Reddy Palleti <avinash.reddy.palleti@intel.com>
+Intel <contact@intel.com> Ritul Jasuja <ritul.jasuja@intel.com>
+Intel <contact@intel.com> Otávio Pontes <otavio.pontes@intel.com>
+Intel <contact@intel.com> Gustavo Jose de Sousa <gustavo.sousa@intel.com>
+Intel <contact@intel.com> Prashanth Shakthi <shakthi.prashanth.m@intel.com>
+Intel <contact@intel.com> Lalit Kumar <lalit.kumar.begani@intel.com>
+Leitwert <contact@leitwert.ch> Simon Laube <simon@leitwert.ch>
+Leitwert <contact@leitwert.ch> Jan Okle <jan@leitwert.ch>
+MIT <contact@mit.edu> Mohammed Kabir <kabir@uasys.io>
+Nuttx <contact@nuttx.org> Greg Nutt <gnutt@nuttx.org>
+PX4 Bots <contact@px4.io> PX4 Jenkins <bot@pixhawk.org>
+Qualcomm <contact@qualcomm.com> Mark Charlebois <charlebm@gmail.com>
+Qualcomm <contact@qualcomm.com> Jim Wilson <jwilson@qti.qualcomm.com>
+Qualcomm <contact@qualcomm.com> bharathr <bharathr@qti.qualcomm.com>
+Teal Drones <contact@tealdrones.com> Jake Dahl <jacob.dahl@tealdrones.com>
+Teal Drones <contact@tealdrones.com> Alex Klimaj <alex.klimaj@tealdrones.com>
+Teal Drones <contact@tealdrones.com> Mark Sauder <mcsauder@gmail.com>
+UAVenture <contact@uaventure.com> Andreas Antener <antener_a@gmx.ch>
+Unaffiliated <no@organization.net> Daniel Agar <daniel@agar.ca>
+Unaffiliated <no@organization.net> David Sidrane <david_s5@nscdg.com>
+Unaffiliated <no@organization.net> dw.xiong <1308455330@qq.com>
+Unaffiliated <no@organization.net> githubDLG <oneshot.triplekill@qq.com>
+Unaffiliated <no@organization.net> Anthony Lamping <lamping.ap@gmail.com>
+Unaffiliated <no@organization.net> Nathan Tsoi <nathan@vertile.com>
+Unaffiliated <no@organization.net> Nuno Marques <n.marques21@hotmail.com>
+Unaffiliated <no@organization.net> Nick Anthony <nickmanthony@hotmail.com>
+Unaffiliated <no@organization.net> SungTae Moon <munhoney@gmail.com>
+Unaffiliated <no@organization.net> Phillip Kocmoud <phil@itchy.io>
+Unaffiliated <no@organization.net> David Riseborough <drisebor@hotmail.com>
+Unaffiliated <no@organization.net> Mateusz Sadowski <msadowski90@gmail.com>
+Unaffiliated <no@organization.net> rolandash <ning.roland@gmail.com>
+Unaffiliated <no@organization.net> Joshua Whitehead <josh.whitehead@dornerworks.com>
+Unaffiliated <no@organization.net> Amir Melzer <amir.melzer@mavt.ethz.ch>
+Unaffiliated <no@organization.net> Alexandr Kondratev <theg4sh@gmail.com>
+Unaffiliated <no@organization.net> Andrew Tridgell <andrew@tridgell.net>
+Unaffiliated <no@organization.net> Don Gagne <don@thegagnes.com>
+Unaffiliated <no@organization.net> Matthias Riegler <riegler.matthias2@gmail.com>
+Vertical Technologies <contact@verticaltechnologies.com> Sander Smeets <sander@droneslab.com>
+Wingtra <contact@wingtra.com> Carl Olsson <carlolsson.co@gmail.com>
+Wingtra <contact@wingtra.com> Sebastian Verling <sverling@student.ethz.ch>
+Yuneec Research <contact@yuneecresearch.com> Julian Oes <julian@oes.ch>
+Yuneec Research <contact@yuneecresearch.com> Dennis Mannhart <dennis@yuneecresearch.com>
+Yuneec Research <contact@yuneecresearch.com> Alessandro Simovic <alessandro@yuneecresearch.com>
+Yuneec Research <contact@yuneecresearch.com> Simone Guscetti <simone@yuneecresearch.com>
+Yuneec Research <contact@yuneecresearch.com> Martina Rivizzigno <martina@rivizzigno.it>
+Yuneec Research <contact@yuneecresearch.com> Matthias Grob <maetugr@gmail.com>
+Yuneec Research <contact@yuneecresearch.com> Christoph Tobler <christoph@yuneecresearch.com>
+Yuneec <contact@yuneec.com> Jun-Tao <jt.li@yuneec.com>
+Yuneec USA <contact@usa.yuneec.com> Sushma Sathyanarayana <sush.satyan@gmail.com>
+#
+# Local Variables:
+# compile-command: "git log --pretty='%aN <%aE>' | \
+#   git -c mailmap.file=.organizationmap check-mailmap --stdin | \
+#   sort | uniq -c | sort -rn | nl"
+# End:


### PR DESCRIPTION
initial dump from PX4/QGC mailmap/orgmap, there's a simple way to test this (using one year as data sample)

Contributor list (clean)
```
git log --pretty='%aN <%aE>' --since="1 year" | sort | uniq -c | sort -rn

  78 Matthias Riegler <riegler.matthias2@gmail.com>
  12 Jonas Vautherin <jonas.vautherin@gmail.com>
   2 Ramón Roche <mrpollo@gmail.com>
   2 Julian Oes <julian@oes.ch>
   2 Hamish Willee <hamishwillee@gmail.com>
```

Organization list
```
git log --pretty='%aN <%aE>' --since="1 year" | git -c mailmap.file=.organizationmap check-mailmap --stdin | sort | uniq -c | sort -rn

  78 Unaffiliated <no@organization.net>
  14 Auterion <contact@auterion.com>
   2 Yuneec Research <contact@yuneecresearch.com>
   2 Dronecode <contact@dronecode.com>
```