### PR TITLE
Add support for return values

### DIFF
--- a/dronecode_sdk/__init__.py
+++ b/dronecode_sdk/__init__.py
@@ -3,8 +3,10 @@
 # List of the core plugins
 CORE_PLUGINS = [
     "Action",
+    "Calibration",
     "Camera",
     "Gimbal",
+    "Info",
     "Mission",
     "Telemetry"
     ]

--- a/examples/firmware_version.py
+++ b/examples/firmware_version.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+import asyncio
+
+from dronecode_sdk import connect as dronecode_sdk_connect
+
+drone = dronecode_sdk_connect(host="127.0.0.1")
+
+
+async def run():
+
+    info_result, info = await drone.info.getVersion()
+    print(f"getVersion result: {info_result.result_str}")
+    print()
+    print(info)
+
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(run())

--- a/examples/mission.py
+++ b/examples/mission.py
@@ -17,13 +17,13 @@ async def run():
     await drone.mission.setReturnToLaunchAfterMission(True)
 
     mission_items = MissionItems(my_items)
-    upload_mission_status, _ = await drone.mission.uploadMission(mission_items)
+    upload_mission_status = await drone.mission.uploadMission(mission_items)
     print(f"-- Upload mission: {upload_mission_status}")
 
-    arm_status, _ = await drone.action.arm()
+    arm_status = await drone.action.arm()
     print(f"-- Arm result: {arm_status}")
 
-    start_mission_status, _ = await drone.mission.startMission()
+    start_mission_status = await drone.mission.startMission()
     print(f"-- Start mission: {start_mission_status}")
 
 

--- a/examples/takeoff_and_land.py
+++ b/examples/takeoff_and_land.py
@@ -9,19 +9,15 @@ drone = dronecode_sdk_connect(host="127.0.0.1")
 
 async def run():
 
-    arm_result, _ = await drone.action.arm()
+    arm_result = await drone.action.arm()
     print(f"-- Arm result: {arm_result}")
 
-    # We do not need to proceed if the copter did not take off
-    if not arm_result:
-        return
-
-    takeoff_result, _ = await drone.action.takeoff()
+    takeoff_result = await drone.action.takeoff()
     print(f"-- Takeoff result: {takeoff_result}")
 
     await asyncio.sleep(5)
 
-    land_result, _ = await drone.action.land()
+    land_result = await drone.action.land()
     print(f"-- Land result: {land_result}")
 
 

--- a/examples/telemetry_takeoff_and_land.py
+++ b/examples/telemetry_takeoff_and_land.py
@@ -8,19 +8,19 @@ drone = dronecode_sdk_connect(host="127.0.0.1")
 
 async def run():
     """ Arms the system, initiates a takeof and finally lands the system """
-    arm_status, _ = await drone.action.arm()
+    arm_status = await drone.action.arm()
     print(f"-- Arm result: {arm_status}")
 
     # We do not need to proceed if the copter did not take off
     if not arm_status:
         return
 
-    takeoff_result, _ = await drone.action.takeoff()
+    takeoff_result = await drone.action.takeoff()
     print(f"-- Takeoff result: {takeoff_result}")
 
     await asyncio.sleep(5)
 
-    land_result, _ = await drone.action.land()
+    land_result = await drone.action.land()
     print(f"-- Land result: {land_result}")
 
 

--- a/other/templates/call.j2
+++ b/other/templates/call.j2
@@ -19,4 +19,4 @@ async def {{ name.lower_camel_case }}(self{% for param in params %}, {{ param.na
     {% endfor -%}
     response = await self._stub.{{ name.upper_camel_case }}(request)
 
-    return self._parse_response(response)
+    return self._extract_result(response)

--- a/other/templates/enum.j2
+++ b/other/templates/enum.j2
@@ -13,10 +13,13 @@ class {{ name.upper_camel_case }}(Enum):
             }.get(self.value, None)
 
     @staticmethod
-    def translate_from_rpc(response):
+    def translate_from_rpc(rpc_enum_value):
         """ Parses a gRPC response """
         return {
             {%- for value in values %}
-                {{ loop.index - 1 }}: "{{ value.uppercase }}",
+                {{ loop.index - 1 }}: {% if parent_struct is not none %}{{ parent_struct.upper_camel_case }}.{% endif %}{{ name.upper_camel_case }}.{{ value.uppercase }},
             {%- endfor %}
-            }.get(response.{{ name.lower_snake_case }}, None)
+            }.get(rpc_enum_value, None)
+
+    def __str__(self):
+        return self.name

--- a/other/templates/file.j2
+++ b/other/templates/file.j2
@@ -27,14 +27,14 @@ class {{ plugin_name.upper_camel_case }}(AsyncBase):
         """ Setups the api stub """
         self._stub = {{ plugin_name.lower_snake_case }}_pb2_grpc.{{ plugin_name.upper_camel_case }}ServiceStub(channel)
 
-    def _parse_response(self, response):
+    def _extract_result(self, response):
         """ Returns the response status and description. If there is no result, it means that it always succeeds. """
         try:
             response.{{ plugin_name.lower_snake_case }}_result
         except AttributeError:
-            return {{ plugin_name.lower_snake_case }}_pb2.{{ plugin_name.upper_camel_case }}Result.SUCCESS, "Success"
+            return {{ plugin_name.upper_camel_case }}Result({{ plugin_name.upper_camel_case }}Result.Result.SUCCESS, "Success")
         else:
-            return {{ plugin_name.upper_camel_case }}Result.Result.translate_from_rpc(response.{{ plugin_name.lower_snake_case }}_result), response.{{ plugin_name.lower_snake_case }}_result.result_str
+            return {{ plugin_name.upper_camel_case }}Result.translate_from_rpc(response.{{ plugin_name.lower_snake_case }}_result)
 
     {%- for method in methods -%}
     {{ '\n' + indent(method, 1) }}

--- a/other/templates/request.j2
+++ b/other/templates/request.j2
@@ -18,5 +18,10 @@ async def {{ name.lower_camel_case }}(self{% for param in params %}, {{ param.na
         {% endif %}
     {% endfor -%}
     response = await self._stub.{{ name.upper_camel_case }}(request)
+    result = self._extract_result(response)
 
-    return response
+    {% if return_type.is_primitive -%}
+    return result, response.{{ return_name.lower_snake_case }}
+    {% else -%}
+    return result, {{ return_type.name }}.translate_from_rpc(response.{{ return_name.lower_snake_case }})
+    {% endif %}

--- a/other/templates/stream.j2
+++ b/other/templates/stream.j2
@@ -9,7 +9,7 @@ async def {{ name.lower_snake_case }}(self{% for param in params %}, {{ param.na
         {%- if return_type.is_primitive %}
             yield response.{{ return_name.lower_snake_case }}
         {%- else %}
-            yield {{ return_type.name }}.translate_from_rpc(response)
+            yield {{ return_type.name }}.translate_from_rpc(response.{{ return_name.lower_snake_case }})
         {%- endif %}
     finally:
         {{ name.lower_snake_case }}_stream.cancel()

--- a/other/templates/struct.j2
+++ b/other/templates/struct.j2
@@ -28,19 +28,26 @@ class {{ name.upper_camel_case }}:
         except AttributeError:
             return False
 
-    def __repr__(self):
+    def __str__(self):
         """ {{ name.upper_camel_case }} in string representation """
-        return "{{ name.upper_camel_case }}" + ", ".join(
+        struct_repr = ", ".join([
                 {%- for field in fields %}
-                self.{{ field.name.lower_snake_case }}{{ "," if not loop.last }}
-                {%- endfor %})
+                "{{ field.name.lower_snake_case }}: " + str(self.{{ field.name.lower_snake_case }}){{ "," if not loop.last }}
+                {%- endfor %}
+                ])
+
+        return f"{{ name.upper_camel_case }}: [{struct_repr}]"
 
     @staticmethod
     def translate_from_rpc(rpc{{ name.upper_camel_case }}):
         """ Translates a gRPC struct to the SDK equivalent """
         return {{ name.upper_camel_case }}(
                 {%- for field in fields %}
-                rpc{{ name.upper_camel_case }}.{{ name.lower_snake_case }}.{{ field.name.lower_snake_case }}{{ "," if not loop.last }}
+                {% if field.type_info.is_primitive %}
+                rpc{{ name.upper_camel_case }}.{{ field.name.lower_snake_case }}{{ "," if not loop.last }}
+                {% else %}
+                {{ name.upper_camel_case }}.{{ field.type_info.inner_name }}.translate_from_rpc(rpc{{ name.upper_camel_case }}.{{ field.name.lower_snake_case }}){{ "," if not loop.last }}
+                {% endif %}
                 {%- endfor %})
 
     def translate_to_rpc(self, rpc{{ name.upper_camel_case }}):


### PR DESCRIPTION
* Enable Calibration and Info plugins
* Add example for Info plugin (examples/firmware_version.py)
* Add support for return values (e.g. to actually get the version from the info plugin, instead of only querying it and never receiving it)
* Improve API by hiding gRPC (we now generate our own types, as in Swift)