### PR TITLE
Handle SUCCESS, IN_PROGRESS and INSTRUCTION in streams

### DIFF
--- a/other/templates/call.j2
+++ b/other/templates/call.j2
@@ -23,5 +23,5 @@ async def {{ name.lower_camel_case }}(self{% for param in params %}, {{ param.na
     result = self._extract_result(response)
 
     if result.result is not {{ plugin_name.upper_camel_case }}Result.Result.SUCCESS:
-        raise {{ plugin_name.upper_camel_case }}Error(result, "{{ name.lower_camel_case }}"{% for param in params %}, {{ param.name.lower_snake_case }}{% endfor %})
+        raise {{ plugin_name.upper_camel_case }}Error(result, "{{ name.lower_snake_case }}()"{% for param in params %}, {{ param.name.lower_snake_case }}{% endfor %})
     {% endif %}

--- a/other/templates/request.j2
+++ b/other/templates/request.j2
@@ -23,7 +23,7 @@ async def {{ name.lower_camel_case }}(self{% for param in params %}, {{ param.na
     result = self._extract_result(response)
 
     if result.result is not {{ plugin_name.upper_camel_case }}Result.Result.SUCCESS:
-        raise {{ plugin_name.upper_camel_case }}Error(result, "{{ name.lower_camel_case }}"{% for param in params %}, {{ param.name.lower_snake_case }}{% endfor %})
+        raise {{ plugin_name.upper_camel_case }}Error(result, "{{ name.lower_snake_case }}()"{% for param in params %}, {{ param.name.lower_snake_case }}{% endfor %})
     {% endif %}
 
     {% if return_type.is_primitive -%}

--- a/other/templates/stream.j2
+++ b/other/templates/stream.j2
@@ -8,8 +8,19 @@ async def {{ name.lower_snake_case }}(self{% for param in params %}, {{ param.na
         async for response in {{ name.lower_snake_case }}_stream:
             {% if has_result %}
             result = self._extract_result(response)
-            if result.result is not {{ plugin_name.upper_camel_case }}Result.Result.SUCCESS:
-                raise {{ plugin_name.upper_camel_case }}Error(result, "{{ name.lower_camel_case }}"{% for param in params %}, {{ param.name.lower_snake_case }}{% endfor %})
+
+            success_codes = [{{ plugin_name.upper_camel_case }}Result.Result.SUCCESS]
+            if 'IN_PROGRESS' in [return_code.name for return_code in {{ plugin_name.upper_camel_case }}Result.Result]:
+                success_codes.append({{ plugin_name.upper_camel_case }}Result.Result.IN_PROGRESS)
+            if 'INSTRUCTION' in [return_code.name for return_code in {{ plugin_name.upper_camel_case }}Result.Result]:
+                success_codes.append({{ plugin_name.upper_camel_case }}Result.Result.INSTRUCTION)
+
+            if result.result not in success_codes:
+                raise {{ plugin_name.upper_camel_case }}Error(result, "{{ name.lower_snake_case }}()"{% for param in params %}, {{ param.name.lower_snake_case }}{% endfor %})
+
+            if result.result is {{ plugin_name.upper_camel_case }}Result.Result.SUCCESS:
+                {{ name.lower_snake_case }}_stream.cancel();
+                return
             {% endif %}
 
         {%- if return_type.is_primitive %}


### PR DESCRIPTION
* Close the stream from the client side when `SUCCESS` is sent (in the future, this should be done from the server side).
* Handle `IN_PROGRESS` and `INSTRUCTION` (in the future, those should disappear and only `SUCCESS` and `NEXT` will be success codes).

Tested with calibration and mission examples.