### PR TITLE
fix: use parent_type from type_info when translating struct

### DIFF
--- a/other/templates/struct.j2
+++ b/other/templates/struct.j2
@@ -46,7 +46,7 @@ class {{ name.upper_camel_case }}:
                 {% if field.type_info.is_primitive %}
                 rpc{{ name.upper_camel_case }}.{{ field.name.lower_snake_case }}{{ "," if not loop.last }}
                 {% else %}
-                {{ name.upper_camel_case }}.{{ field.type_info.inner_name }}.translate_from_rpc(rpc{{ name.upper_camel_case }}.{{ field.name.lower_snake_case }}){{ "," if not loop.last }}
+                {% if field.type_info.parent_type is not none %}{{ field.type_info.parent_type }}.{% endif %}{{ field.type_info.inner_name }}.translate_from_rpc(rpc{{ name.upper_camel_case }}.{{ field.name.lower_snake_case }}){{ "," if not loop.last }}
                 {% endif %}
                 {%- endfor %})
 

--- a/other/tools/run_protoc.sh
+++ b/other/tools/run_protoc.sh
@@ -36,7 +36,7 @@ function generate {
         python3 -m grpc_tools.protoc -I$(dirname ${PROTO_FILE}) \
                                      --plugin=protoc-gen-custom=$(which dcsdkgen) \
                                      --custom_out=${PLUGIN_DIR} \
-                                     --custom_opt=py \
+                                     --custom_opt=file_ext=py \
                                      ${PROTO_FILE}
 
         WANTED_PLUGIN_NAME="$(echo ${PROTO_FILE} | sed "s#.*/\(.*\).proto#\1#g").py"


### PR DESCRIPTION
* Fix generation for nested structs.
* Use `file_ext` option when running protoc, following latest changes in dcsdkgen

@zulufoxtrot: FYI

Resolves #47.