### PR TITLE
Update proto submodule with offboard proto def and core plugin list.

### DIFF
--- a/dronecode_sdk/__init__.py
+++ b/dronecode_sdk/__init__.py
@@ -18,6 +18,7 @@ CORE_PLUGINS = [
     "Gimbal",
     "Info",
     "Mission",
+    "Offboard",
     "Telemetry"
     ]
 


### PR DESCRIPTION
There are a number of commits between the one for adding `offboard.proto` and the current commit hash (`a54b353d73`), need someone to verify it is OK to include them.