### PR TITLE
dcsdkgen got renamed to protoc-gen-dcsdk

### DIFF
--- a/other/tools/run_protoc.sh
+++ b/other/tools/run_protoc.sh
@@ -34,7 +34,7 @@ function generate {
 
         # Generate plugin
         python3 -m grpc_tools.protoc -I$(dirname ${PROTO_FILE}) \
-                                     --plugin=protoc-gen-custom=$(which dcsdkgen) \
+                                     --plugin=protoc-gen-custom=$(which protoc-gen-dcsdk) \
                                      --custom_out=${PLUGIN_DIR} \
                                      --custom_opt=file_ext=py \
                                      ${PROTO_FILE}


### PR DESCRIPTION
@unipheas: this should fix your build issue, but you may have to reinstall the plugin.

I tested in a venv with:

```sh
# Clone the repo
git clone https://github.com/dronecode/dronecodesdk-python
cd dronecodesdk-python

# Create and activate a venv
python -m venv venv
source ./venv/bin/activate

# Install the protoc plugin, now called `protoc-gen-dcsdk`
cd proto/pb_plugins
pip install -r requirements.txt
pip install -e .

# Go back to root of repo and generate the SDK
cd ../..
pip install -r requirements.txt -r requirements-dev.txt
sh other/tools/run_protoc.h

# Optional: check that the protoc plugin is correctly installed in the venv:
which protoc-gen-dcsdk
```