### PR TITLE
dronecode_sdk: set development status and programming language

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,11 +46,10 @@ setup(
     include_package_data=True,
 
     classifiers=[
-        "Development Status :: 3 - Production/Alpha",
+        "Development Status :: 3 - Alpha",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: Apache Software License",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
     ],
 
     packages=find_packages(exclude=["other", "docs", "tests", "examples",


### PR DESCRIPTION
- I realized it has to be "Production" OR "Alpha" :laughing:.
- We don't support all of Python 3, so my hope is that setting Python 3.6 means that it works for Python 3.6+. @xvzf do you know about that?